### PR TITLE
Frontend GetTicket API does not acquire locks.

### DIFF
--- a/pkg/statestore/statestore.go
+++ b/pkg/statestore/statestore.go
@@ -15,7 +15,9 @@ var (
 type StateStore interface {
 	CreateTicket(ctx context.Context, ticket *pb.Ticket) error
 	DeleteTicket(ctx context.Context, ticketID string) error
+	// GetTicket is an API to retrieve the status of a single ticket and is called from Frontend.
 	GetTicket(ctx context.Context, ticketID string) (*pb.Ticket, error)
+	// GetTickets on the other hand, retrieves multiple tickets at once and is intended to be called from Backend.
 	GetTickets(ctx context.Context, ticketIDs []string) ([]*pb.Ticket, error)
 	GetAssignment(ctx context.Context, ticketID string) (*pb.Assignment, error)
 	GetActiveTicketIDs(ctx context.Context, limit int64) ([]string, error)


### PR DESCRIPTION
Frontend GetTicket API no longer calls deIndexTickets because Backend's GetTickets does it asynchronously. Therefore, Frontend no longer needs to acquire the ticket index lock, which improves Redis performance.